### PR TITLE
Remove Ning async HTTP client dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <url>https://github.com/librato/dropwizard-librato</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <metrics.librato.version>4.1.2.0</metrics.librato.version>
+        <metrics.librato.version>4.1.2.3</metrics.librato.version>
         <dropwizard.metrics.version>0.9.1</dropwizard.metrics.version>
     </properties>
     <licenses>

--- a/src/main/java/io/dropwizard/metrics/LibratoReporterFactory.java
+++ b/src/main/java/io/dropwizard/metrics/LibratoReporterFactory.java
@@ -5,9 +5,9 @@ import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Optional;
+import com.librato.metrics.DefaultHttpPoster;
 import com.librato.metrics.HttpPoster;
 import com.librato.metrics.LibratoReporter;
-import com.librato.metrics.NingHttpPoster;
 import io.dropwizard.util.Duration;
 
 import javax.validation.constraints.NotNull;
@@ -73,7 +73,7 @@ public class LibratoReporterFactory extends BaseReporterFactory {
             builder.setSourceRegex(sourceRegexPattern);
         }
         if (libratoUrl != null) {
-            HttpPoster httpPoster = NingHttpPoster.newPoster(username, token, libratoUrl);
+            HttpPoster httpPoster = new DefaultHttpPoster(libratoUrl, username, token);
             builder.setHttpPoster(httpPoster);
         }
         if (prefix != null) {


### PR DESCRIPTION
This uses a new version of metrics-librato which transitively uses a new version of librato-java which removes the Ning async HTTP client dependency in favor of an HTTP client that uses only the stdlib classes.