### PR TITLE
Upgrade to dropwizard 1.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.librato.metrics</groupId>
     <artifactId>dropwizard-metrics-librato</artifactId>
-    <version>0.9.1.6-SNAPSHOT</version>
+    <version>1.0.3.0-SNAPSHOT</version>
     <name>Metrics Librato Dropwizard Support</name>
     <url>https://github.com/librato/dropwizard-librato</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <metrics.librato.version>4.1.2.5</metrics.librato.version>
-        <dropwizard.metrics.version>0.9.1</dropwizard.metrics.version>
+        <dropwizard.metrics.version>1.0.3</dropwizard.metrics.version>
     </properties>
     <licenses>
         <license>
@@ -53,6 +53,15 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
@@ -97,6 +106,7 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-metrics</artifactId>
             <version>${dropwizard.metrics.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.librato.metrics</groupId>

--- a/src/main/java/io/dropwizard/metrics/LibratoReporterFactory.java
+++ b/src/main/java/io/dropwizard/metrics/LibratoReporterFactory.java
@@ -4,7 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.google.common.base.Optional;
+import java.util.Optional;
 import com.librato.metrics.DefaultHttpPoster;
 import com.librato.metrics.HttpPoster;
 import com.librato.metrics.LibratoReporter;


### PR DESCRIPTION
The factory only has to change from guava's `Optional` to `java.util.Optional`.

The pom must be updated to reflec the requirement on 1.8, as well as upgraded libs.

@collinvandyck 